### PR TITLE
Database cleanup

### DIFF
--- a/app/Character.php
+++ b/app/Character.php
@@ -10,6 +10,8 @@ class Character extends Model
   use Notifiable;
 
   protected $guarded = [];
+  public $incrementing = false;
+  protected $primaryKey = 'character_id';
 
   public function routeNotificationForDiscord() {
     $this->discord_webhook;
@@ -20,6 +22,6 @@ class Character extends Model
   }
    
   public function structures() {
-    return $this->hasMany(\App\Structures, 'corporation_id', 'corporation_id');
+    return $this->hasMany('App\Structure', 'corporation_id', 'corporation_id');
   }
 }

--- a/app/Character.php
+++ b/app/Character.php
@@ -10,9 +10,16 @@ class Character extends Model
   use Notifiable;
 
   protected $guarded = [];
-    //
+
   public function routeNotificationForDiscord() {
     $this->discord_webhook;
   }
-    
+
+  public function corporation_id() {
+    return $this->corporation_id;
+  }
+   
+  public function structures() {
+    return $this->hasMany(\App\Structures, 'corporation_id', 'corporation_id');
+  }
 }

--- a/app/Console/Commands/CheckOrphans.php
+++ b/app/Console/Commands/CheckOrphans.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Jobs\OrphanStructure;
+
+class CheckOrphans extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'check:orphans';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cleanup orphaned structures from deleted characters and accounts';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+      OrphanStructure::dispatch();
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends ConsoleKernel
         //          ->hourly();
       $schedule->command('update:structures')->cron('0 */3 * * *');
       $schedule->command('check:fuel')->hourly();
+      $schedule->command('check:orphans')->weekly();
     }
 
     /**

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -28,11 +28,7 @@ class CharacterController extends Controller
     }
     try {
       Character::where('character_id', $character->character_id)->delete();
-      Structure::where('character_id', $character->character_id)->delete();
-      StructureService::where('character_id', $character->character_id)->delete();
-      StructureState::where('character_id', $character->character_id)->delete();
-      StructureVul::where('character_id', $character->character_id)->delete();
-
+  
       $client = new Client();
       $authsite = 'https://login.eveonline.com/oauth/revoke';
       $tokens = array($character->refresh_token, $character->access_token);

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use DB;
 use Illuminate\Http\Request;
 use App\User;
 use App\Character;
@@ -34,11 +35,15 @@ class HomeController extends Controller
       $success = $success[0];
       $warning = $warning[0];
 
-
       $characters = User::find(auth()->id())->characters; 
-      $structures = User::find(auth()->id())->structures; 
-
-
+      $structures = DB::table('users')
+                    ->join('characters', 'users.id', '=', 'characters.user_id')
+                    ->join('structures', 'structures.corporation_id', '=', 'characters.corporation_id')
+                    ->where('users.id',  auth()->id())
+                    ->where('characters.is_manager', TRUE)
+                    ->select('structures.*')
+                    ->distinct()
+                    ->get();
       return view('home', compact(['characters', 'structures', 'alert', 'success', 'warning']));
     }
 

--- a/app/Http/Controllers/StructureController.php
+++ b/app/Http/Controllers/StructureController.php
@@ -302,7 +302,6 @@ class StructureController extends Controller
         return redirect()->to('/home')->with('alert', [$alert]);
       } catch (\Exception $e) {
         //Everything else
-        dd($e);
         $alert = "We failed to pull the Structure name from ESI, Try again later.";
         return redirect()->to('/home')->with('alert', [$alert]);
       }

--- a/app/Http/Controllers/StructureController.php
+++ b/app/Http/Controllers/StructureController.php
@@ -232,7 +232,7 @@ class StructureController extends Controller
            'unanchors_at' => $unanchors_at,
            'state' => $state
           ]
-        );
+        )->touch();
 
         $current_services = StructureService::select('name')
                           ->where('structure_id', $strct->structure_id)

--- a/app/Http/Controllers/StructureController.php
+++ b/app/Http/Controllers/StructureController.php
@@ -144,10 +144,10 @@ class StructureController extends Controller
     //Delete Structures and relations that aren't returned in the API call
     foreach($current_structures as $cs) {
       if(!in_array($cs->structure_id, $api_structures)) {
-        Structure::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-        StructureService::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-        StructureState::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-        StructureVul::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
+        Structure::find($cs->structure_id)->services()->delete();
+        Structure::find($cs->structure_id)->states()->delete();
+        Structure::find($cs->structure_id)->vuls()->delete();
+        Structure::where('structure_id', $cs->structure_id)->delete();
       }
     }
 

--- a/app/Jobs/LowFuelCheck.php
+++ b/app/Jobs/LowFuelCheck.php
@@ -34,57 +34,73 @@ class LowFuelCheck implements ShouldQueue
      */
     public function handle()
     {
-      $structures = Structure::where('fuel_expires', '!=', 'n/a')->get();
+      $structures = Structure::all();
       foreach ($structures as $structure) {
-        $character = Character::where('character_id', $structure->character_id)->where('user_id', $structure->user_id)->first();
-        Log::debug("Starting FuelCheck for $structure->structure_name owned by $character->character_name on user_id $structure->user_id"); 
+        $characters = Structure::find($structure->structure_id)->characters;
+        foreach ($characters as $character) {
+          Log::debug("Starting FuelCheck for $structure->structure_name owned by $character->character_name"); 
 
-        if(!isset($character->discord_webhook) || is_null($character->discord_webhook)) {
-          Log::debug("Ending FuelCheck for $structure->structure_name , no discord_webhook"); 
-          continue;
-        }
-        $days_left = $structure->fuel_days_left;
-        $fuel_notices = FuelNotice::where('user_id', $structure->user_id)
-                                  ->where('structure_id', $structure->structure_id)
-                                  ->where('character_id', $structure->character_id)->first();
-
-        if($days_left < 1) {
-          if((isset($fuel_notices) && $fuel_notices->twentyfour_hour == FALSE ) || !isset($fuel_notices->twentyfour_hour)) {
-            //Notify for <24hrs fuel if we haven't already, mark it notified
-            Log::debug("Sending 24hour notice (days left are $days_left) for $structure->structure_name owned by $character->character_name on user_id $structure->user_id"); 
+          if(!isset($character->discord_webhook) || is_null($character->discord_webhook)) {
+            //If the fuel were to run out, we want to reset the notifications
             FuelNotice::updateOrCreate(
-              ['structure_id' => $structure->structure_id, 'user_id' => $structure->user_id],
-              ['twentyfour_hour' => TRUE, 'character_id' => $structure->character_id]); 
-            $character->notify(new LowFuelDiscord($structure)); 
-          }
-        } elseif($days_left > 0 && $days_left <= 7) {
-            if((isset($fuel_notices) && $fuel_notices->seven_day == FALSE) || !isset($fuel_notices->seven_day)) {
-              //Notify if more than 1 day and less than 7 if we haven't already, mark it notified
-              Log::debug("Sending 7day notice (days left are $days_left) for $structure->structure_name owned by $character->character_name on user_id $structure->user_id"); 
-              FuelNotice::updateOrCreate(
-                ['structure_id' => $structure->structure_id, 'user_id' => $structure->user_id],
-                ['seven_day' => TRUE, 'twentyfour_hour' => FALSE, 'character_id' => $structure->character_id]
-              ); 
-              $character->notify(new LowFuelDiscord($structure)); 
-          } elseif(isset($fuel_notices)) {
-              //If we are above 1 day, but less than 7 and we HAVE notified then mark the 24hour as not sent
-              // This catches people who only refuel for less than a week that we already notified for 24 hours
-              FuelNotice::updateOrCreate(
-                ['structure_id' => $structure->structure_id, 'user_id' => $structure->user_id],
-                ['seven_day' => TRUE, 'twentyfour_hour' => FALSE, 'character_id' => $structure->character_id]
-              ); 
-          }
-        } elseif($days_left > 7) {
-            //reset all the notifications, we can do them all again
-            FuelNotice::updateOrCreate(
-              ['structure_id' => $structure->structure_id, 'user_id' => $structure->user_id],
-              ['seven_day' => FALSE, 'twentyfour_hour' => FALSE, 'character_id' => $structure->character_id]
+              ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+              ['seven_day' => FALSE, 'twentyfour_hour' => FALSE]
             ); 
-        
-        } else {
-          //nothing
+            Log::debug("Ending FuelCheck for $structure->structure_name for $character->character_name, no discord_webhook"); 
+            continue;
+          }
+
+          if($structure->fuel_expires == 'n/a') {
+            FuelNotice::updateOrCreate(
+              ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+              ['seven_day' => FALSE, 'twentyfour_hour' => FALSE]
+            ); 
+            Log::debug("Ending FuelCheck for $structure->structure_name for $character->character_name, no fuel"); 
+            continue;
+          }
+
+          $days_left = $structure->fuel_days_left;
+          $fuel_notices = FuelNotice::where('structure_id', $structure->structure_id)
+                                    ->where('character_id', $character->character_id)->first();
+
+          if($days_left < 1) {
+            if((isset($fuel_notices) && $fuel_notices->twentyfour_hour == FALSE ) || !isset($fuel_notices->twentyfour_hour)) {
+              //Notify for <24hrs fuel if we haven't already, mark it notified
+              Log::debug("Sending 24hour notice (days left are $days_left) for $structure->structure_name owned by $character->character_name"); 
+              FuelNotice::updateOrCreate(
+                ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+                ['twentyfour_hour' => TRUE]); 
+              $character->notify(new LowFuelDiscord($structure)); 
+            }
+          } elseif($days_left > 0 && $days_left <= 7) {
+              if((isset($fuel_notices) && $fuel_notices->seven_day == FALSE) || !isset($fuel_notices->seven_day)) {
+                //Notify if more than 1 day and less than 7 if we haven't already, mark it notified
+                Log::debug("Sending 7day notice (days left are $days_left) for $structure->structure_name owned by $character->character_name"); 
+                FuelNotice::updateOrCreate(
+                  ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+                  ['seven_day' => TRUE, 'twentyfour_hour' => FALSE]
+                ); 
+                $character->notify(new LowFuelDiscord($structure)); 
+            } elseif(isset($fuel_notices)) {
+                //If we are above 1 day, but less than 7 and we HAVE notified then mark the 24hour as not sent
+                // This catches people who only refuel for less than a week that we already notified for 24 hours
+                FuelNotice::updateOrCreate(
+                  ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+                  ['seven_day' => TRUE, 'twentyfour_hour' => FALSE]
+                ); 
+            }
+          } elseif($days_left > 7) {
+              //reset all the notifications, we can do them all again
+              FuelNotice::updateOrCreate(
+                ['structure_id' => $structure->structure_id, 'character_id' => $character->character_id],
+                ['seven_day' => FALSE, 'twentyfour_hour' => FALSE]
+              ); 
+          
+          } else {
+            //Nothing
+          }
+          Log::debug("Ending FuelCheck for $structure->structure_name for $character->character_name");  
         }
-      Log::debug("Ending FuelCheck for $structure->structure_name");  
       }
     }
 }

--- a/app/Jobs/OrphanStructure.php
+++ b/app/Jobs/OrphanStructure.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Log;
+use App\Structure;
+use App\StructureService;
+use App\StructureState;
+use App\StructureVul;
+
+class OrphanStructure implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+      $structures = Structure::all();
+      foreach ($structures as $structure) {
+        $characters = Structure::find($structure->structure_id)->characters;
+        if(count($characters) < 1) {
+          Log::debug("Deleting $structure->structure_name and attached services, states and vuls , no owners found");
+          $structure->delete();
+
+          StructureService::where('structure_id', $structure->structure_id)->delete();
+          StructureState::where('structure_id', $structure->structure_id)->delete();
+          StructureVul::where('structure_id', $structure->structure_id)->delete();
+
+        }
+      }
+    }
+}

--- a/app/Jobs/OrphanStructure.php
+++ b/app/Jobs/OrphanStructure.php
@@ -9,9 +9,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Log;
 use App\Structure;
-use App\StructureService;
-use App\StructureState;
-use App\StructureVul;
 
 class OrphanStructure implements ShouldQueue
 {
@@ -39,12 +36,10 @@ class OrphanStructure implements ShouldQueue
         $characters = Structure::find($structure->structure_id)->characters;
         if(count($characters) < 1) {
           Log::debug("Deleting $structure->structure_name and attached services, states and vuls , no owners found");
+          Structure::find($structure->structure_id)->services()->delete();
+          Structure::find($structure->structure_id)->states()->delete();
+          Structure::find($structure->structure_id)->vuls()->delete();
           $structure->delete();
-
-          StructureService::where('structure_id', $structure->structure_id)->delete();
-          StructureState::where('structure_id', $structure->structure_id)->delete();
-          StructureVul::where('structure_id', $structure->structure_id)->delete();
-
         }
       }
     }

--- a/app/Jobs/StructureUpdate.php
+++ b/app/Jobs/StructureUpdate.php
@@ -89,9 +89,15 @@ class StructureUpdate implements ShouldQueue
 
       if(!in_array("Station_Manager", $roles->roles)) {
         $alert = "Character {$this->character->character_name} doesn't have the Station Manager Role, this is required to pull Corporation Structures. Once added please wait at least 60 minutes before trying again.";
+        $this->character->is_manager = FALSE;
+        $this->character->save;
         Log::error("{$this->character->character_name} does not have the Station Manager role");
         return;
-      } 
+      } else {
+        $this->character->is_manager = TRUE;
+        $this->character->save;
+
+      }
 
       try {
         $structure_url = "/v2/corporations/{$this->character->corporation_id}/structures/";
@@ -109,7 +115,7 @@ class StructureUpdate implements ShouldQueue
       }
 
       $current_structures = Structure::select('structure_id')
-                            ->where('character_id', $this->character->character_id)
+                            ->('corporation_id', $this->character->corporation_id)
                             ->get();  
 
       $api_structures = array();
@@ -120,10 +126,10 @@ class StructureUpdate implements ShouldQueue
       //Delete Structures and relations that aren't returned in the API call
       foreach($current_structures as $cs) {
         if(!in_array($cs->structure_id, $api_structures)) {
-          Structure::where('structure_id', $cs->structure_id)->where('character_id', $this->character->character_id)->delete();
-          StructureService::where('structure_id', $cs->structure_id)->where('character_id', $this->character->character_id)->delete();
-          StructureState::where('structure_id', $cs->structure_id)->where('character_id', $this->character->character_id)->delete();
-          StructureVul::where('structure_id', $cs->structure_id)->where('character_id', $this->character->character_id)->delete();
+          Structure::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
+          StructureService::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
+          StructureState::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
+          StructureVul::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
         }
       }
 
@@ -194,9 +200,8 @@ class StructureUpdate implements ShouldQueue
           $state = str_replace("_", " " , $strct->state);
 
           Structure::updateOrCreate(
-            ['structure_id' => $strct->structure_id, 'character_id' => $this->character->character_id],
+            ['structure_id' => $strct->structure_id],
             ['structure_name' => $unv->name,
-             'user_id' => $this->character->user_id,
              'corporation_id' => $this->character->corporation_id,
              'type_id' => $strct->type_id,
              'type_name' => $type_name,
@@ -213,7 +218,6 @@ class StructureUpdate implements ShouldQueue
 
           $current_services = StructureService::select('name')
                             ->where('structure_id', $strct->structure_id)
-                            ->where('character_id', $this->character->character_id)
                             ->get();  
 
           if(count($current_services) > 0 && isset($strct->services)) {
@@ -227,14 +231,12 @@ class StructureUpdate implements ShouldQueue
               if(!in_array($cs->name, $api_services)) {
                 StructureService::where('structure_id', $strct->structure_id)
                                   ->where('name', $cs->name)
-                                  ->where('character_id', $this->character->character_id)
                                   ->delete();
               }
             }
           } elseif(count($current_services) > 0 && !isset($strct->services)) {
               //IF no services are returned, delete them all
               StructureService::where('structure_id', $strct->structure_id)
-                                ->where('character_id', $this->character->character_id)
                                 ->delete();
 
           }
@@ -242,7 +244,7 @@ class StructureUpdate implements ShouldQueue
           if(isset($strct->services)) {
             foreach($strct->services as $sr) {
               StructureService::updateOrCreate(
-                ['structure_id' => $strct->structure_id, 'character_id' => $this->character->character_id],
+                ['structure_id' => $strct->structure_id],
                 ['state' => $sr->state,
                  'name' => $sr->name]
               );
@@ -253,7 +255,7 @@ class StructureUpdate implements ShouldQueue
           $state_timer_end = isset($strct->state_timer_end) ? str_replace($tz, " ", $strct->state_timer_end) : null;
 
           StructureState::updateOrCreate(
-            ['structure_id' => $strct->structure_id, 'character_id' => $this->character->character_id],
+            ['structure_id' => $strct->structure_id],
             ['state_timer_start' => $state_timer_start,
              'state_timer_end' => $state_timer_end,
              'state' => $state]
@@ -272,7 +274,7 @@ class StructureUpdate implements ShouldQueue
           }
 
           StructureVul::updateOrCreate(
-            ['structure_id' => $strct->structure_id, 'character_id' => $this->character->character_id],
+            ['structure_id' => $strct->structure_id],
             ['day' => $days[$strct->reinforce_weekday], 'hour' => $strct->reinforce_hour,
              'next_day' => $next_day, 'next_hour' => $next_hour, 'next_reinforce_apply' => $next_apply]
           );

--- a/app/Jobs/StructureUpdate.php
+++ b/app/Jobs/StructureUpdate.php
@@ -126,10 +126,10 @@ class StructureUpdate implements ShouldQueue
       //Delete Structures and relations that aren't returned in the API call
       foreach($current_structures as $cs) {
         if(!in_array($cs->structure_id, $api_structures)) {
-          Structure::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-          StructureService::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-          StructureState::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
-          StructureVul::where('structure_id', $cs->structure_id)->where('corporation_id', $cs->corporation_id)->delete();
+          Structure::find($cs->structure_id)->services()->delete();
+          Structure::find($cs->structure_id)->states()->delete();
+          Structure::find($cs->structure_id)->vuls()->delete();
+          Structure::where('structure_id', $cs->structure_id)->delete();
         }
       }
 

--- a/app/Jobs/StructureUpdate.php
+++ b/app/Jobs/StructureUpdate.php
@@ -115,7 +115,7 @@ class StructureUpdate implements ShouldQueue
       }
 
       $current_structures = Structure::select('structure_id')
-                            ->('corporation_id', $this->character->corporation_id)
+                            ->where('corporation_id', $this->character->corporation_id)
                             ->get();  
 
       $api_structures = array();

--- a/app/Jobs/StructureUpdate.php
+++ b/app/Jobs/StructureUpdate.php
@@ -214,7 +214,7 @@ class StructureUpdate implements ShouldQueue
              'unanchors_at' => $unanchors_at,
              'state' => $state
             ]
-          );
+          )->touch();
 
           $current_services = StructureService::select('name')
                             ->where('structure_id', $strct->structure_id)

--- a/app/Notifications/LowFuelDiscord.php
+++ b/app/Notifications/LowFuelDiscord.php
@@ -45,7 +45,7 @@ class LowFuelDiscord extends Notification
         $embed->description(':warning: **Fuel Alert** :warning:');
         $embed->color( 15105570 );
         $embed->thumbnail("https://imageserver.eveonline.com/Type/{$this->structure->type_id}_64.png");
-        $embed->author(env('APP_NAME'). 'Bot', null, "https://imageserver.eveonline.com/Character/{$this->structure->character_id}_64.jpg");
+        $embed->author(env('APP_NAME'). 'Bot', null, "https://imageserver.eveonline.com/Character/{$notifiable->character_id}_64.jpg");
         $embed->field('Fuel Remaining', $this->structure->fuel_time_left, TRUE);
         $embed->field('Fuel Expiration', $this->structure->fuel_expires, TRUE);
         $embed->field('System', $this->structure->system_name, TRUE);

--- a/app/Structure.php
+++ b/app/Structure.php
@@ -7,5 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class Structure extends Model
 {
     protected $guarded = [];
-    //
+    public $incrementing = false;
+    protected $primaryKey = 'structure_id';
+
+
+    public function characters() {
+      return $this->hasMany('App\Character', 'corporation_id', 'corporation_id');
+    }
 }

--- a/app/Structure.php
+++ b/app/Structure.php
@@ -10,8 +10,21 @@ class Structure extends Model
     public $incrementing = false;
     protected $primaryKey = 'structure_id';
 
-
     public function characters() {
       return $this->hasMany('App\Character', 'corporation_id', 'corporation_id');
     }
+
+    public function services() {
+      return $this->hasMany('App\StructureService', 'structure_id', 'structure_id');
+    }
+
+    public function states() {
+      return $this->hasMany('App\StructureState', 'structure_id', 'structure_id');
+    }
+
+    public function vuls() {
+      return $this->hasMany('App\StructureVul', 'structure_id', 'structure_id');
+    }
+
 }
+

--- a/app/StructureService.php
+++ b/app/StructureService.php
@@ -7,5 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class StructureService extends Model
 {
   protected $guarded = [];
+  public $incrementing = false;
+  protected $primaryKey = 'structure_id';
     //
 }

--- a/app/StructureState.php
+++ b/app/StructureState.php
@@ -7,5 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class StructureState extends Model
 {
   protected $guarded = [];
+  public $incrementing = false;
+  protected $primaryKey = 'structure_id';
     //
 }

--- a/app/StructureVul.php
+++ b/app/StructureVul.php
@@ -7,4 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class StructureVul extends Model
 {
   protected $guarded = [];
+  public $incrementing = false;
+  protected $primaryKey = 'structure_id';
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -32,9 +32,4 @@ class User extends Authenticatable
       return $this->hasMany(Character::class);
     }
 
-    public function structures() {
-      return $this->hasMany(Structure::class);
-    }
-
-
 }

--- a/database/migrations/2018_02_18_220046_remove_chr_userid_from_structures.php
+++ b/database/migrations/2018_02_18_220046_remove_chr_userid_from_structures.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveChrUseridFromStructures extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('structures', function (Blueprint $table) {
+          $table->dropColumn('user_id');
+          $table->dropColumn('character_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('structures', function (Blueprint $table) {
+            $table->bigInteger('character_id');
+            $table->integer('user_id');
+            //
+        });
+    }
+}

--- a/database/migrations/2018_02_18_220303_rmv_char_id_structure_services.php
+++ b/database/migrations/2018_02_18_220303_rmv_char_id_structure_services.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RmvCharIdStructureServices extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('structure_services', function (Blueprint $table) {
+          $table->dropColumn('character_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('structure_services', function (Blueprint $table) {
+          $table->bigInteger('character_id');
+        });
+    }
+}

--- a/database/migrations/2018_02_18_220438_rmv_char_id_structure_states.php
+++ b/database/migrations/2018_02_18_220438_rmv_char_id_structure_states.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RmvCharIdStructureStates extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('structure_states', function (Blueprint $table) {
+          $table->dropColumn('character_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('structure_states', function (Blueprint $table) {
+          $table->bigInteger('character_id');
+        });
+    }
+}

--- a/database/migrations/2018_02_18_220546_rmv_char_id_structure_vuls.php
+++ b/database/migrations/2018_02_18_220546_rmv_char_id_structure_vuls.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RmvCharIdStructureVuls extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('structure_vuls', function (Blueprint $table) {
+          $table->dropColumn('character_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('structure_vuls', function (Blueprint $table) {
+          $table->bigInteger('character_id');
+        });
+    }
+}

--- a/database/migrations/2018_02_18_220648_add_role_to_characters.php
+++ b/database/migrations/2018_02_18_220648_add_role_to_characters.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddRoleToCharacters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+          $table->boolean('is_manager')->default(FALSE);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+          $table->dropColumn('is_manager');
+        });
+    }
+}

--- a/database/migrations/2018_02_19_034724_drop_user_id_fuel_notice.php
+++ b/database/migrations/2018_02_19_034724_drop_user_id_fuel_notice.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropUserIdFuelNotice extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('fuel_notices', function (Blueprint $table) {
+          $table->dropColumn('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('fuel_notices', function (Blueprint $table) {
+          $table->integer('user_id');
+        });
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -120,7 +120,7 @@
             </thead>
 
             @foreach($structures as $str) <!-- Loop over structures -->
-            @if($str->character_id == $char->character_id)
+            @if($str->corporation_id == $char->corporation_id && $char->is_manager == TRUE)
             <tr>
               <td><img src="https://imageserver.eveonline.com/Type/{{$str->type_id}}_32.png"></td>
               <td><a href="{{ url('/home/structure') }}/{{$str->structure_id}}">{{$str->structure_name}}</a></td>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -113,9 +113,9 @@
             <tr>
               <th></th>
               <th>Station Name</th>
-              <th>System</th>
               <th>State</th>
               <th>Fuel</th>
+              <th>Updated</th>
             </tr>
             </thead>
 
@@ -124,13 +124,13 @@
             <tr>
               <td><img src="https://imageserver.eveonline.com/Type/{{$str->type_id}}_32.png"></td>
               <td><a href="{{ url('/home/structure') }}/{{$str->structure_id}}">{{$str->structure_name}}</a></td>
-              <td>{{$str->system_name}}</td>
               <td>{{ucwords($str->state)}}</td>
               @if(is_null($str->fuel_days_left))
               <td>{{$str->fuel_expires}}</td>
               @else
               <td class="@if($str->fuel_days_left <= 1)one_day @elseif($str->fuel_days_left < 30)thirty_less @elseif($str->fuel_days_left >= 30)thirty_plus @else @endif">{{$str->fuel_time_left}}</td>
               @endif
+              <td>{{$str->updated_at}}</td>
             </tr>
             @endif
             @endforeach


### PR DESCRIPTION
These changes reduce duplicate entries in the database when multiple characters from the same corporation are added to the same account, or additional accounts. Rework the models, jobs, controllers to adapt to the `hasMany` relationships. 

Now when a character/account is deleted the structures are left behind in case other characters who are Station Managers are using their data. Created a new job to run once a week to check for the orphaned structures that have had all their characters deleted, and removes them. (if you're concerned about security, this information is next to useless as its now stale and can't be updated). 