### PR TITLE
Update .env.example, set debug to false

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 


### PR DESCRIPTION
This shouldn't be enabled by default. Leaving this to true exposes database credentials to the public for any error the client encounters. Not to mention everything else in .env