### PR TITLE
php7.4 fixes

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -31,9 +31,10 @@ class HomeController extends Controller
       $alert = session()->pull('alert');
       $success = session()->pull('success');
       $warning = session()->pull('warning');
-      $alert = $alert[0];
-      $success = $success[0];
-      $warning = $warning[0];
+      $alert = isset($alert[0]) ? $alert[0] : null;
+      $success = isset($success[0]) ? $success[0] : null;
+      $warning = isset($warning[0]) ? $warning[0] : null;
+
 
       $characters = User::find(auth()->id())->characters; 
       $structures = DB::table('users')

--- a/app/Http/Controllers/NotificationManagerController.php
+++ b/app/Http/Controllers/NotificationManagerController.php
@@ -17,10 +17,9 @@ class NotificationManagerController extends Controller
     $alert = session()->pull('alert');
     $success = session()->pull('success');
     $warning = session()->pull('warning');
-    $alert = $alert[0];
-    $success = $success[0];
-    $warning = $warning[0];
-
+    $alert = isset($alert[0]) ? $alert[0] : null;
+    $success = isset($success[0]) ? $success[0] : null;
+    $warning = isset($warning[0]) ? $warning[0] : null;
 
     $characters = DB::table('characters')->where('user_id', auth()->id())->where('is_manager', TRUE)->select('character_id')->get();
     foreach($characters as $char) {

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -9,8 +9,8 @@ class WelcomeController extends Controller
   public function index() {
       $alert = session()->pull('alert');
       $success = session()->pull('success');
-      $alert = $alert[0];
-      $success = $success[0];
+      $alert = isset($alert[0]) ? $alert[0] : null;
+      $success = isset($success[0]) ? $success[0] : null;
       return view('welcome', compact(['alert', 'success']));
 
   }


### PR DESCRIPTION
https://www.php.net/manual/en/migration74.incompatible.php

Serveral fixes from this:

``` 
$alert = $alert[0];
$warning = $warning[0];
$success = $success[0];
```

To this:

```
$alert = isset($alert[0]) ? $alert[0] : null;
$warning = isset($warning[0]) ? $warning[0] : null;
$success = isset($success[0]) ? $success[0] : null;
```
